### PR TITLE
Créer le dossier "datagouv" qui fusionne tables usagers et véhicules

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -36,3 +36,6 @@ models:
     # Applies to all files under models/example/
     example:
       materialized: view
+    datagouv:
+      materialized: table   ## au niveau du dossier "staging" dans models
+      schema: 'datagouv'

--- a/models/datagouv/usagers.sql
+++ b/models/datagouv/usagers.sql
@@ -1,0 +1,21 @@
+-- Model pour créer la table usagers complète de 2005 à 2021
+-- Les tables usagers 2005 à 2018 ont une structure légèrement différente de celles de 2019 à 2021 (notamment pas d'id_vehicule !), d'où la requête suivante :
+
+SELECT
+  Num_Acc
+  ,NULL as id_vehicule
+  ,num_veh
+  ,catu
+  ,grav
+  ,sexe
+  ,an_nais
+  ,trajet
+  ,secu AS secu1
+  ,NULL AS secu2
+  ,NULL AS secu3
+  ,etatp
+FROM whowillcrash.datagouv.usagers_2005_2018
+UNION ALL
+SELECT
+  *
+FROM datagouv.usagers_2019_2020_2021

--- a/models/datagouv/vehicules.sql
+++ b/models/datagouv/vehicules.sql
@@ -1,0 +1,19 @@
+-- Les tables vehicules 2005 à 2018 ont une structure légèrement différente de celles de 2019 à 2021 (notamment pas d'id_vehicule !), d'où la requête suivante :
+
+SELECT
+  Num_Acc
+  ,NULL AS id_vehicule
+  ,num_veh
+  ,senc
+  ,catv
+  ,obs
+  ,obsm
+  ,choc
+  ,manv
+  ,NULL AS motor
+  ,occutc
+FROM `whowillcrash.datagouv.vehicules_2005_2018`
+UNION ALL
+SELECT
+  *
+FROM `datagouv.vehicules_2019_2020_2021`


### PR DESCRIPTION
Créer le dossier "datagouv" qui contient deux modèles, un pour fusionner les tables usagers (qui avaient des structures différentes à gérer), un pour fusionner les tables vehicules (qui avaient aussi des structures différentes)