### PR TITLE
Dans la table usagers, recoder "secu" de pré-2018 en "secu1"

### DIFF
--- a/models/datagouv/usagers.sql
+++ b/models/datagouv/usagers.sql
@@ -10,7 +10,16 @@ SELECT
   ,sexe
   ,an_nais
   ,trajet
-  ,secu AS secu1
+  ,CASE
+    WHEN secu IN (1,11) THEN 1
+    WHEN secu IN (2,21) THEN 2
+    WHEN secu IN (3,31) THEN 3
+    WHEN secu IN (4,41) THEN 4
+    WHEN secu IN (9,91) THEN 9
+    WHEN secu IN (0,12,22,32,42,92) THEN 0
+    WHEN secu IN (13,23,33,43,93) THEN 8
+    ELSE -1
+   END AS secu1
   ,NULL AS secu2
   ,NULL AS secu3
   ,etatp


### PR DESCRIPTION
Jusqu'en 2018, secu était codé sur 2 caractères :
le premier concerne l’existence d’un Équipement de sécurité
1 – Ceinture
2 – Casque
3 – Dispositif enfants
4 – Equipement réfléchissant
9 – Autre
le second concerne l’utilisation de l’Équipement de sécurité
1 – Oui
2 – Non
3 – Non déterminable